### PR TITLE
Add Open Graph image and social sharing meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,17 @@
   <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=DM+Mono:ital,wght@0,300;0,400;0,500;1,300;1,400;1,500&display=swap" rel="stylesheet">
 
+  <!-- Open Graph -->
+  <meta property="og:title" content="Infer Vancouver: AI Engineering Meetup">
+  <meta property="og:description" content="Vancouver's meetup for tactics, techniques, and lessons learned in LLM and AI engineering.">
+  <meta property="og:image" content="https://infervan.com/images/og-image.png">
+  <meta property="og:url" content="https://infervan.com">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Infer Vancouver: AI Engineering Meetup">
+  <meta name="twitter:description" content="Vancouver's meetup for tactics, techniques, and lessons learned in LLM and AI engineering.">
+  <meta name="twitter:image" content="https://infervan.com/images/og-image.png">
+
   <!-- favicon -->
   <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />


### PR DESCRIPTION
## Summary
- Adds Open Graph and Twitter Card meta tags to [index.html](index.html) so link previews render with a custom image and description
- Adds [images/og-image.png](images/og-image.png) (2400x1260, 2x Retina for the 1200x630 OG spec) featuring the Infer hex logo and "Infer speaker series / AI engineering meetup" text

## Test plan
- [ ] CI checks pass
- [ ] After merge, verify preview on Facebook Sharing Debugger (https://developers.facebook.com/tools/debug/)
- [ ] After merge, verify preview on Twitter/X Card Validator
- [ ] After merge, verify preview in Slack/iMessage link unfurl

Generated with [Claude Code](https://claude.com/claude-code)